### PR TITLE
Apply workaround for avoiding Lablgtk2's Gdk.GC.get_values and GDraw.drawable#set_line_attributes

### DIFF
--- a/gtk_ext.ml
+++ b/gtk_ext.ml
@@ -31,7 +31,7 @@
 *)
 class better_drawable ?colormap w pc = 
 object
-  inherit GDraw.drawable ?colormap w
+  inherit GDraw.drawable ?colormap w as super
 
   (** Link a writable Pango context for easy access. *)
   val pango_context = (pc : GPango.context_rw)
@@ -39,15 +39,28 @@ object
   (** Return a writable Pango context. *)
   method pango_context = pango_context    
 
+  val mutable fg_color = GDraw.color (`NAME "black");
+  val mutable bg_color = GDraw.color (`NAME "white");
+
   (** Return the current foreground color of the graphics context of
       this drawable. 
   *)
-  method get_foreground = (Gdk.GC.get_values gc).Gdk.GC.foreground
+  method get_foreground = fg_color;
 
   (** Return the current background color of the graphics context of
       this drawable. 
   *)
-  method get_background = (Gdk.GC.get_values gc).Gdk.GC.background
+  method get_background = bg_color;
+
+  (* override GDraw.drawable#set_foreground *)
+  method set_foreground c =
+    super#set_foreground c;
+    fg_color <- GDraw.color c
+ 
+  (* override GDraw.drawable#set_background *)
+  method set_background c =
+    super#set_background c;
+    bg_color <- GDraw.color c                          
 end
 
 

--- a/proof_window.ml
+++ b/proof_window.ml
@@ -304,8 +304,9 @@ object (self)
   (** Reflect changes in the current configuration. *)
   method configuration_updated =
     sequent_window#misc#modify_font !sequent_font_desc;
-    drawable#set_line_attributes 
-      ~width:(!current_config.turnstile_line_width) ();
+    Gdk.GC.set_line_attributes (drawable#gc)
+      ~width:(!current_config.turnstile_line_width)
+      ~style:`SOLID ~cap:`ROUND ~join:`ROUND;
     layer_stack#configuration_updated;
     self#expand_drawing_area;
     ignore(self#position_tree);
@@ -1441,8 +1442,9 @@ let rec make_proof_window name geometry_string =
            ~callback:(proof_window#context_menu_deactivated));
 
   top_window#set_title (name ^ " proof tree");
-  drawable#set_line_attributes 
-    ~width:(!current_config.turnstile_line_width) ();
+  Gdk.GC.set_line_attributes (drawable#gc)
+    ~width:(!current_config.turnstile_line_width)
+    ~style:`SOLID ~cap:`ROUND ~join:`ROUND;
   drawing_area#misc#set_has_tooltip true;
   ignore(drawing_area#misc#connect#query_tooltip
    	   ~callback:proof_window#drawable_tooltip);


### PR DESCRIPTION
On Mac (macOS Sierra), the function `Gdk.GC.get_values` of Lablgtk 2.18.5 or `gdk_gc_get_values()` of GTK+ 2.24.32 does not seem to work correctly. It seems that `ml_gdk_gc_get_values()` in `ml_gdk.c` of Lablgtk 2.18.5 returns an unacceptable (maybe uninitialized) set of values which causes exceptions. Although I have not seen any trouble of this kind on ubuntu machines, prooftree on Mac did not work without applying some modification to `ml_gdk.c` of Lablgtk2.

I'd like to offer another way to avoid the problem. The patch make prooftree avoid using `Gdk.GC.get_values` and `GDraw.drawable#set_line_attributes` of Lablgtk2. The workaround looks fine for me.
